### PR TITLE
Add validation for the output handler

### DIFF
--- a/Microsoft.PowerShell.Crescendo/test/ErrorConditions.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/ErrorConditions.Tests.ps1
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe "Error Condition Tests" -Tag CI {
+    Context "Output Handler Faults" {
+        It "will report a syntax error" {
+            $configuration = Import-CommandConfiguration -file $PSScriptRoot/assets/HandlerFault1.json -ErrorVariable handlerFault -ErrorAction SilentlyContinue
+            $configuration | Should Not BeNullOrEmpty
+            $handlerFault | Should Not BeNullOrEmpty
+            $handlerFault.TargetObject.Count | Should Be 1
+            $handlerFault.TargetObject[0].ErrorId | Should Be "MissingEndCurlyBrace"
+        }
+        It "will report multiple syntax errors" {
+            $configuration = Import-CommandConfiguration -file $PSScriptRoot/assets/HandlerFault2.json -ErrorVariable handlerFault -ErrorAction SilentlyContinue
+            $configuration | Should Not BeNullOrEmpty
+            $handlerFault | Should Not BeNullOrEmpty
+            $handlerFault.TargetObject.Count | Should Be 2
+            $handlerFault.TargetObject[0].ErrorId | Should Be "ExpectedValueExpression"
+            $handlerFault.TargetObject[1].ErrorId | Should Be "MissingEndCurlyBrace"
+        }
+        It "Will properly identify the parameter set" {
+            $configuration = Import-CommandConfiguration -file $PSScriptRoot/assets/HandlerFault3.json -ErrorVariable handlerFault -ErrorAction SilentlyContinue
+            $configuration | Should Not BeNullOrEmpty
+            $handlerFault | Should Not BeNullOrEmpty
+            $handlerFault.Exception.Message | Should Match "pset1"
+        }
+    }
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault1.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault1.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+    "Verb": "Test",
+    "Noun": "HandlerError",
+    "OriginalName": "doesnotexist",
+    "OutputHandlers": [
+        {
+            "ParameterSetName": "Default",
+            "StreamOutput": true,
+            "Handler": "PROCESS { $_.oTime = [datetime]::now; $_"
+        }
+    ]
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault2.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault2.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+    "Verb": "Test",
+    "Noun": "HandlerError",
+    "OriginalName": "doesnotexist",
+    "OutputHandlers": [
+        {
+            "ParameterSetName": "Default",
+            "StreamOutput": true,
+            "Handler": "PROCESS { $_.oTime = "
+        }
+    ]
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault3.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault3.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+    "Verb": "Test",
+    "Noun": "HandlerError",
+    "OriginalName": "doesnotexist",
+    "OutputHandlers": [
+        {
+            "ParameterSetName": "pset1",
+            "StreamOutput": true,
+            "Handler": "PROCESS { $_.oTime = [datetime]::now; $_"
+        }
+    ]
+}


### PR DESCRIPTION
Check for parser errors
Create a few tests to check the new behavior

It's pretty easy to make a mistake with the output handlers, this creates some checking with improved error reporting.

Inspired by https://github.com/PowerShell/Crescendo/pull/61/files and thanks @kvprasoon