### PR TITLE
Add cmdlet docs and fix typos

### DIFF
--- a/Microsoft.PowerShell.Crescendo/help/Export-CrescendoModule.md
+++ b/Microsoft.PowerShell.Crescendo/help/Export-CrescendoModule.md
@@ -1,0 +1,149 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/export-crescendomodule?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# Export-CrescendoModule
+
+## SYNOPSIS
+Creates a module from PowerShell Crescendo JSON configuration files
+
+## SYNTAX
+
+```
+Export-CrescendoModule [-ConfigurationFile] <String[]> [-ModuleName] <String> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This cmdlet exports an object that can be converted into a function that acts as a proxy for a
+platform specific command. The resultant module file should be executable down to version 5.1 of
+PowerShell.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```
+Export-CrescendoModule -ModuleName netsh -ConfigurationFile netsh*.json
+Import-Module ./netsh.psm1
+```
+
+### EXAMPLE 2
+
+```
+Export-CrescendoModule netsh netsh*.json -force
+```
+
+## PARAMETERS
+
+### -ConfigurationFile
+
+This is a list of JSON files which represent the proxies for the module
+
+```yaml
+Type: System.String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: True
+```
+
+### -Force
+
+By default, if `Export-CrescendoModule` finds an already created module, it will not overwrite the
+existing file. Use the **Force** parameter to overwrite the existing file, or remove it prior to
+running `Export-CrescendoModule`.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+
+The name of the module file you wish to create. You can omit the trailing `.psm1`.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+Internally, this function calls the `Import-CommandConfiguration` cmdlet that returns a command
+object. All files provided in the **ConfigurationFile** parameter are then used to create each
+individual function. Finally, all proxies are used to create an `Export-ModuleMember` command
+invocation, so when the resultant module is imported, the module has all the command proxies
+available.
+
+## RELATED LINKS
+
+[Import-CommandConfiguration](Import-CommandConfiguration.md)

--- a/Microsoft.PowerShell.Crescendo/help/Export-Schema.md
+++ b/Microsoft.PowerShell.Crescendo/help/Export-Schema.md
@@ -1,0 +1,46 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/export-schema?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# Export-Schema
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Export-Schema
+```
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Microsoft.PowerShell.Crescendo/help/Import-CommandConfiguration.md
+++ b/Microsoft.PowerShell.Crescendo/help/Import-CommandConfiguration.md
@@ -1,0 +1,88 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/import-commandconfiguration?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# Import-CommandConfiguration
+
+## SYNOPSIS
+Import a PowerShell Crescendo json file.
+
+## SYNTAX
+
+```
+Import-CommandConfiguration [[-file] <String>]
+```
+
+## DESCRIPTION
+
+This cmdlet exports an object that can be converted into a function that acts as a proxy for the
+platform specific command. The resultant object may then be used to call a native command that can
+participate in the PowerShell pipeline. The `ToString` method of the output object returns a
+string that can be used to create a function that calls the native command. Microsoft Windows,
+Linux, and macOS can run the generated function, if the native command is on all of the platform.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Import-CommandConfiguration ifconfig.crescendo.json
+```
+
+```output
+Verb                    : Invoke
+Noun                    : ifconfig
+OriginalName            : ifconfig
+OriginalCommandElements :
+Aliases                 :
+DefaultParameterSetName :
+SupportsShouldProcess   : False
+SupportsTransactions    : False
+NoInvocation            : False
+Description             : This is a description of the generated function
+Usage                   : .SYNOPSIS
+                          Run invoke-ifconfig
+Parameters              : {[Parameter()]
+                          [string]$Interface = ""}
+Examples                :
+OriginalText            :
+HelpLinks               :
+OutputHandlers          :
+```
+
+## PARAMETERS
+
+### -file
+
+The json file which represents the command to be wrapped.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## INPUTS
+
+## OUTPUTS
+
+### A Command object
+
+## NOTES
+
+The object returned by `Import-CommandConfiguration` is converted through the `ToString` method.
+Generally, you should use the `Export-CrescendoModule`, which creates a PowerShell `.psm1` file.
+
+## RELATED LINKS
+
+[Export-CrescendoModule](Export-CrescendoModule.md)

--- a/Microsoft.PowerShell.Crescendo/help/Microsoft.PowerShell.Crescendo.md
+++ b/Microsoft.PowerShell.Crescendo/help/Microsoft.PowerShell.Crescendo.md
@@ -1,0 +1,37 @@
+---
+Module Name: Microsoft.PowerShell.Crescendo
+Module Guid: 2dd09744-1ced-4636-a8ce-09a0bf0e566a
+ms.date: 03/16/2021
+Download Help Link: https://aka.ms/ps-modules-help
+Help Version: 0.1.0.0
+Locale: en-US
+---
+
+# Microsoft.PowerShell.Crescendo Module
+
+## Description
+
+{{ Fill in the Description }}
+
+## Microsoft.PowerShell.Crescendo Cmdlets
+
+### [Export-CrescendoModule](Export-CrescendoModule.md)
+{{ Fill in the Description }}
+
+### [Export-Schema](Export-Schema.md)
+{{ Fill in the Description }}
+
+### [Import-CommandConfiguration](Import-CommandConfiguration.md)
+{{ Fill in the Description }}
+
+### [New-CrescendoCommand](New-CrescendoCommand.md)
+{{ Fill in the Description }}
+
+### [New-ExampleInfo](New-ExampleInfo.md)
+{{ Fill in the Description }}
+
+### [New-ParameterInfo](New-ParameterInfo.md)
+{{ Fill in the Description }}
+
+### [New-UsageInfo](New-UsageInfo.md)
+{{ Fill in the Description }}

--- a/Microsoft.PowerShell.Crescendo/help/New-CrescendoCommand.md
+++ b/Microsoft.PowerShell.Crescendo/help/New-CrescendoCommand.md
@@ -1,0 +1,85 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/new-crescendocommand?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# New-CrescendoCommand
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+New-CrescendoCommand [-Verb] <String> [-Noun] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Noun
+
+{{ Fill Noun Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verb
+
+{{ Fill Verb Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Microsoft.PowerShell.Crescendo/help/New-ExampleInfo.md
+++ b/Microsoft.PowerShell.Crescendo/help/New-ExampleInfo.md
@@ -1,0 +1,101 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/new-exampleinfo?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# New-ExampleInfo
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+New-ExampleInfo [-command] <String> [-originalCommand] <String> [-description] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -command
+
+{{ Fill command Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -description
+
+{{ Fill description Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -originalCommand
+
+{{ Fill originalCommand Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Microsoft.PowerShell.Crescendo/help/New-ParameterInfo.md
+++ b/Microsoft.PowerShell.Crescendo/help/New-ParameterInfo.md
@@ -1,0 +1,85 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/new-parameterinfo?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# New-ParameterInfo
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+New-ParameterInfo [-Name] <String> [-OriginalName] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Name
+
+{{ Fill Name Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OriginalName
+
+{{ Fill OriginalName Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Microsoft.PowerShell.Crescendo/help/New-UsageInfo.md
+++ b/Microsoft.PowerShell.Crescendo/help/New-UsageInfo.md
@@ -1,0 +1,69 @@
+---
+external help file: Microsoft.PowerShell.Crescendo-help.xml
+Module Name: Microsoft.PowerShell.Crescendo
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/new-usageinfo?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+---
+
+# New-UsageInfo
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+New-UsageInfo [-usage] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -usage
+
+{{ Fill usage Description }}
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Microsoft.PowerShell.Crescendo/help/en-US/about_Crescendo.md
+++ b/Microsoft.PowerShell.Crescendo/help/en-US/about_Crescendo.md
@@ -1,41 +1,49 @@
+---
+description: Describes arrays, which are data structures designed to store collections of items.
+Locale: en-US
+ms.date: 03/16/2021
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/about/about_Microsoft.PowerShell.Crescendo?view=ps-modules.1&WT.mc_id=ps-gethelp
+schema: 2.0.0
+title: about_Microsoft.PowerShell.Crescendo
+---
 # Microsoft.PowerShell.Crescendo
 
 ## about_Microsoft.PowerShell.Crescendo
 
-### SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 The PowerShell Crescendo module provides a novel way to create proxy functions
 for native commands via `JSON` configuration files.
 
-### LONG DESCRIPTION
+## LONG DESCRIPTION
 
 PowerShell is capable of invoking native applications like any shell. However,
-it would improve the experience if the native command could participate
-in the PowerShell pipeline and take advantage of the parameter behaviors
-that are part of PowerShell.
+it would improve the experience if the native command could participate in the
+PowerShell pipeline and take advantage of the parameter behaviors that are part
+of PowerShell.
 
-The PowerShell Crescendo module provides a way to more easily
-take advantage of the PowerShell pipeline by
-invoking the native executable, facilitating parameter handling,
-and converting text output into objects.
+The PowerShell Crescendo module provides a way to more easily take advantage of
+the PowerShell pipeline by invoking the native executable, facilitating
+parameter handling, and converting text output into objects.
 
-#### JSON Configuration
+## JSON Configuration
 
-The PowerShell Crescendo module provides a way to create a small bit of json,
-which is then used to create a function which calls the native command.
+The PowerShell Crescendo module provides a way to create a small bit of JSON
+that is used to create a function that calls the native command.
 
-An annotated schema is provided as part of the module which can improve the authoring process.
+An annotated schema is provided as part of the module that can improve the
+authoring process.
 
-#### Parameter handling
+## Parameter handling
 
 The PowerShell Crescendo module allows you to interact with parameters of native
 commands in the same way you do with cmdlets.
 
-#### Output Handling
+## Output Handling
 
-It is also possible to provide a script block which can then be used to convert
-the output from the native command into objects. In case the native command
-emits `json` or `xml` it is as simple as:
+It is also possible to provide a script block that can be used to convert the
+output from the native command into objects. If the native command emits `json`
+or `xml` it is as simple as:
 
 ```json
     "OutputHandler": [
@@ -46,7 +54,7 @@ emits `json` or `xml` it is as simple as:
 
 However, script blocks of arbitrary complexity may also be used.
 
-# EXAMPLES
+## EXAMPLES
 
 A number of samples are provided as part of the module, you can see these in
 the Samples directory in the module base directory.
@@ -75,11 +83,12 @@ The name of the proxy function is `Get-FileList` and has two parameters:
 
 A couple of things to note about the Path parameter
 
-- The `OriginalPosition` is set to 1 and the `OriginalName` is set to an empty string.
-  This is because some native commands have a parameter which is _not_ named and must
-  be the last parameter when executed. All parameters will be ordered by the value
-  of `OriginalPosition` (the default is 0) and when the native command is called,
-  those parameters (and their values) will be put in that order.
+- The `OriginalPosition` is set to 1 and the `OriginalName` is set to an empty
+  string. This is because some native commands have a parameter which is _not_
+  named and must be the last parameter when executed. All parameters will be
+  ordered by the value of `OriginalPosition` (the default is 0) and when the
+  native command is called, those parameters (and their values) will be put in
+  that order.
 
 In this example, there is no output handler defined, so the text output of the
 command will be returned to the pipeline.
@@ -108,10 +117,10 @@ A more complicated example which wraps the linux `apt` command follows:
 
 In this case, the output handler converts the text output to a `pscustomobject`
 to enable using other PowerShell cmdlets. When run, this provides an object
-which encapsulates the apt output
+which encapsulates the `apt` output
 
 ```powershell
-PS> get-installedpackage | ?{ $_.name -match "libc"} 
+PS> get-installedpackage | ?{ $_.name -match "libc"}
 
 Name        Version            Architecture State
 ----        -------            ------------ -----
@@ -129,23 +138,26 @@ Count Name  Group
    82 amd64 {@{Name=apt; Version=2.0.2ubuntu0.1; Architecture=amd64; State=System.String[]}, @{Name=base-files…
 ```
 
-# TROUBLESHOOTING NOTE
+## TROUBLESHOOTING NOTE
 
-The PowerShell Crescendo module is still very early in the development process, so
-we expect changes to be made.
+The PowerShell Crescendo module is still very early in the development process,
+so we expect changes to be made.
 
 One issue is that the output handler is currently a string, so constructing the
-script block may be complex; semi-colons will be required to separate statements.
-This may be addressed in a later version.
+script block may be complex; semi-colons will be required to separate
+statements. This may be addressed in a later version.
 
-# SEE ALSO
+## SEE ALSO
 
-The github repository may be found here: https://github.com/PowerShell/Crescendo
+The GitHub repository may be found at:
+[https://github.com/PowerShell/Crescendo](https://github.com/PowerShell/Crescendo).
 
-PowerShell Blog posts which present the rational and approaches for native
-command wrapping can be found here: [Part 1](https://devblogs.microsoft.com/powershell/native-commands-in-powershell-a-new-approach/)
-[Part 2](https://devblogs.microsoft.com/powershell/native-commands-in-powershell-a-new-approach-part-2))
+PowerShell Blog posts that present the rational and approaches for native
+command wrapping can be found here:
 
-# KEYWORDS
+- [Part 1](https://devblogs.microsoft.com/powershell/native-commands-in-powershell-a-new-approach/)
+- [Part 2](https://devblogs.microsoft.com/powershell/native-commands-in-powershell-a-new-approach-part-2))
+
+## KEYWORDS
 
 Native Command

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -446,10 +446,10 @@ Import a PowerShell Crescendo json file.
 
 .DESCRIPTION
 
-This cmdlet exports an object which can be converted into a function which acts as a proxy for the platform specific command.
-The resultant object may then be used to call a native command which can participate in the PowerShell pipeline.
-The ToString method of the output object will return a string which may be used to create a function which calls the native command.
-Microsoft Windows, Linux, and MacOS can run the generated function, if the command is on all of the platform.
+This cmdlet exports an object that can be converted into a function that acts as a proxy for the platform specific command.
+The resultant object may then be used to call a native command that can participate in the PowerShell pipeline.
+The ToString method of the output object returns a string that can be used to create a function that calls the native command.
+Microsoft Windows, Linux, and macOS can run the generated function, if the native command is on all of the platform.
 
 .PARAMETER File
 
@@ -481,7 +481,7 @@ OutputHandlers          :
 .NOTES
 
 The object returned by Import-CommandConfiguration is converted through the ToString method.
-Generally, you should use the Export-CrescendoModule function which creates a PowerShell .psm1 file.
+Generally, you should use the Export-CrescendoModule function, which creates a PowerShell .psm1 file.
 
 .OUTPUTS
 
@@ -503,7 +503,7 @@ Export-CrescendoModule
             $parserErrors = $null
             if ( -not (Test-Handler -Script $handler.Handler -ParserErrors ([ref]$parserErrors))) {
                 $eArgs = @{
-                    Message = "OutputHandler Error in '{0}-{1}' for ParameterSet '{2}'" -f $configuration.Verb, $configuration.Noun, $handler.ParameterSetName 
+                    Message = "OutputHandler Error in '{0}-{1}' for ParameterSet '{2}'" -f $configuration.Verb, $configuration.Noun, $handler.ParameterSetName
                     Category = "ParserError"
                     TargetObject = $parserErrors
                     ErrorID = "Import-CommandConfiguration:OutputHandler"
@@ -526,22 +526,22 @@ function Export-CrescendoModule
 <#
 .SYNOPSIS
 
-Creates a module from PowerShell Crescendo json configuration files
+Creates a module from PowerShell Crescendo JSON configuration files
 
 .DESCRIPTION
 
-This cmdlet exports an object which can be converted into a function which acts as a proxy for a platform specific command.
+This cmdlet exports an object that can be converted into a function that acts as a proxy for a platform specific command.
 The resultant module file should be executable down to version 5.1 of PowerShell.
 
 
 .PARAMETER ConfigurationFile
 
-This is a list of json files which represent the proxies for the module
+This is a list of JSON files that represent the proxies for the module
 
 .PARAMETER ModuleName
 
 The name of the module file you wish to create.
-You can omit the trailing .psm1
+You can omit the trailing .psm1.
 
 .PARAMETER Force
 
@@ -559,9 +559,9 @@ PS> Export-CrescendoModule netsh netsh*.json -force
 
 .NOTES
 
-Internally, this function calls the Import-CommandConfiguration cmdlet which returns a command object.
+Internally, this function calls the Import-CommandConfiguration cmdlet that returns a command object.
 All files provided in the -ConfigurationFile parameter are then used to create each individual function.
-Finally, all proxies are used to create an Export-ModuleMember command invocation, so when the resultan module is
+Finally, all proxies are used to create an Export-ModuleMember command invocation, so when the resultant module is
 imported, the module has all the command proxies available.
 
 .OUTPUTS
@@ -575,7 +575,7 @@ Import-CommandConfiguration
 #>
     [CmdletBinding(SupportsShouldProcess=$true)]
     param (
-        [Parameter(Position=1,Mandatory=$true,ValueFromPipelineByPropertyName=$true)][string[]]$ConfigurationFile,
+        [Parameter(Position=1,Mandatory=$true,ValueFromPipelineByPropertyName=$true)][SupportsWildcards()][string[]]$ConfigurationFile,
         [Parameter(Position=0,Mandatory=$true)][string]$ModuleName,
         [Parameter()][switch]$Force
         )


### PR DESCRIPTION
- Ran platyPS to create the cmdlet docs. 
- Fixed some grammar and typos. 
- Added `[SupportsWildcards()]` attribute to the **ConfigurationFile** parameter of `Import-CommandConfiguration`