### PR TITLE
Add support for an attribute for the crescendo command 

### DIFF
--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Format.ps1xml
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Format.ps1xml
@@ -22,6 +22,32 @@
      </TableRowEntries>
     </TableControl>
    </View>
+   <View>
+    <Name>CrescendoCommandInfoTable</Name>
+    <ViewSelectedBy>
+     <TypeName>CrescendoCommandInfo</TypeName>
+    </ViewSelectedBy>
+    <GroupBy>
+      <PropertyName>Module</PropertyName>
+      <Label>Module</Label>
+    </GroupBy>
+    <TableControl>
+     <TableHeaders>
+      <TableColumnHeader><Label>Name</Label></TableColumnHeader>
+      <TableColumnHeader><Label>IsCrescendoCommand</Label></TableColumnHeader>
+      <TableColumnHeader><Label>RequiresElevation</Label></TableColumnHeader>
+     </TableHeaders>
+     <TableRowEntries>
+      <TableRowEntry>
+       <TableColumnItems>
+        <TableColumnItem><PropertyName>Name</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>IsCrescendoCommand</PropertyName></TableColumnItem>
+        <TableColumnItem><PropertyName>RequiresElevation</PropertyName></TableColumnItem>
+       </TableColumnItems>
+      </TableRowEntry>
+     </TableRowEntries>
+    </TableControl>
+   </View>
 
    </ViewDefinitions>
 </Configuration>

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
@@ -35,6 +35,7 @@ FunctionsToExport = @(
     'New-UsageInfo',
     'Import-CommandConfiguration',
     'Export-Schema',
-    'Export-CrescendoModule'
+    'Export-CrescendoModule',
+    'Test-IsCrescendoCommand'
     )
 }

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
@@ -20,6 +20,9 @@ Copyright = '(c) Microsoft Corporation. All rights reserved.'
 # Description of the functionality provided by this module
 Description = "Module that improves user experience with native commands"
 
+# Link to updateable help
+HelpInfoUri = 'https://aka.ms/ps-modules-help'
+
 TypesToProcess = 'Microsoft.PowerShell.Crescendo.Types.ps1xml'
 FormatsToProcess = 'Microsoft.PowerShell.Crescendo.Format.ps1xml'
 

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -661,6 +661,10 @@ Import-CommandConfiguration
         if ($ModuleName -notmatch "\.psm1$") {
             $ModuleName += ".psm1"
         }
+        if (-not $PSCmdlet.ShouldProcess("Creating Module '$ModuleName'"))
+        {
+            return
+        }
         if ((Test-Path $ModuleName) -and -not $Force) {
             throw "$ModuleName already exists"
         }
@@ -678,6 +682,9 @@ Import-CommandConfiguration
         '' >> $ModuleName
     }
     PROCESS {
+        if ( $PSBoundParameters['WhatIf'] ) {
+            return
+        }
         $resolvedConfigurationPaths = (Resolve-Path $ConfigurationFile).Path
         foreach($file in $resolvedConfigurationPaths) {
             Write-Verbose "Adding $file to Crescendo collection"
@@ -685,6 +692,9 @@ Import-CommandConfiguration
         }
     }
     END {
+        if ( $PSBoundParameters['WhatIf'] ) {
+            return
+        }
         [string[]]$cmdletNames = @()
         [string[]]$aliases = @()
         [string[]]$SetAlias = @()

--- a/Microsoft.PowerShell.Crescendo/test/CrescendoAttribute.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/CrescendoAttribute.Tests.ps1
@@ -1,0 +1,107 @@
+Describe "Attribute Tests" {
+    BeforeAll {
+        # Create a crescendo module
+        $ModuleName = "tModule"
+        $ModulePath = Join-Path -Path $TESTDRIVE -ChildPath $ModuleName
+        $SamplePath = Join-Path -Path $PSScriptRoot -ChildPath .. -AdditionalChildPath Samples
+        $SampleDir = (Resolve-Path $SamplePath).Path
+        Export-CrescendoModule -ModuleName "${ModulePath}" -Config "${SampleDir}/*.json"
+        $ModuleInfo = Import-Module "${ModulePath}.psd1" -Force -PassThru
+        $mFunctions = Get-Command -Module tModule | Where-Object { $_.CommandType -eq "Function" }
+        $configs = (Get-ChildItem "${SampleDir}/*.json").Foreach({Get-Content $_ | ConvertFrom-Json})
+        $functionTestCases = $mFunctions.ForEach({@{ Name = $_.Name; Function = $_ }})
+        $elevationTestCases = $mFunctions.Foreach({@{ Name = $_.Name; Function = $_; Configuration = $configs }})
+    }
+
+    AfterAll {
+        Remove-Module $ModuleName
+    }
+
+    Context "Command Parameter can accept two different types of objects" {
+
+        It "can accept a string for a function" {
+            function global:get-test1 { }
+            $result = Test-IsCrescendoCommand -Command get-test1
+            Remove-Item function:get-test1
+            $result | Should -Not -BeNullOrEmpty
+            $result.IsCrescendoCommand | Should -Be $false
+        }
+
+        It "can accept a FunctionInfo for a function" {
+            function get-test1 { }
+            $result = Test-IsCrescendoCommand -Command (Get-Command -Name get-test1)
+            $result | Should -Not -BeNullOrEmpty
+            $result.IsCrescendoCommand | Should -Be $false
+        }
+
+        It "can accept a piped string for a function" {
+            function global:get-test1 { }
+            $result = "get-test1" | Test-IsCrescendoCommand
+            Remove-Item function:get-test1
+            $result | Should -Not -BeNullOrEmpty
+            $result.IsCrescendoCommand | Should -Be $false
+        }
+
+        It "can accept a piped FunctionInfo for a function" {
+            function get-test1 { }
+            $result = Get-Command -Name get-test1 | Test-IsCrescendoCommand
+            $result | Should -Not -BeNullOrEmpty
+            $result.IsCrescendoCommand | Should -Be $false
+        }
+
+        It "can accept a collection" {
+            function global:get-test1 { }
+            function get-test2 { }
+            $result = Test-IsCrescendoCommand -Command "get-test1",(Get-Command -name get-test2)
+            remove-item function:get-test1
+            $result.Count | Should -Be 2
+            $result[0].IsCrescendoCommand | Should -Be $false
+            $result[1].IsCrescendoCommand | Should -Be $false
+        }
+
+    }
+
+    Context "Basic Functionality" {
+        It "Identifies the function '<Name>' as being created by Crescendo" -TestCases $functionTestCases {
+            param ( [string]$Name, [System.Management.Automation.FunctionInfo]$Function)
+            $result = $Function | Test-IsCrescendoCommand 
+            $result.IsCrescendoCommand | Should -Be $true
+        }
+
+        It "Properly identifies whether the function '<Name>' will elevate" -TestCases $elevationTestCases {
+            param ( [string]$Name, [System.Management.Automation.FunctionInfo]$Function, [pscustomobject[]]$Configuration)
+            $config = $Configuration.Where({$cmdletName = "{0}-{1}" -f $_.Verb,$_.Noun; $cmdletName -eq $Name})
+            $IsElevated = $config.Elevation -ne $null ? $true : $false
+            $observed = $Function | Test-IsCrescendoCommand
+            $observed.RequiresElevation | Should -Be $IsElevated
+        }
+    }
+
+    Context "Test-IsCrescendoCommand" {
+        It "Will not find crescendo commands if the attribute is not present" {
+            function get-localtest { }
+            $observed = Get-Command -Name get-localtest | Test-IsCrescendoCommand
+            $observed.Module | Should -BeNullOrEmpty
+            $observed.Source | Should -BeNullOrEmpty
+            $observed.IsCrescendoCommand | Should -Be $false
+            $observed.RequiresElevation | Should -Be $false
+        }
+    }
+
+    Context "Error Conditions" {
+        BeforeAll {
+            $cmdName = "Get-Command" # a binary cmdlet that is guaranteed to be present
+            $result = Get-Command -Name $cmdName | Test-IsCrescendoCommand -ErrorAction SilentlyContinue -ErrorVariable badfunction
+        }
+        It "Will properly error when testing a non-function" {
+            #$cmdName = "Get-Command" # a binary cmdlet that is guaranteed to be present
+            #$result = Get-Command -Name $cmdName | Test-IsCrescendoCommand -ErrorAction SilentlyContinue -ErrorVariable badfunction
+            $result | Should -BeNullOrEmpty
+            $badfunction.FullyQualifiedErrorId | Should -Be "Microsoft.PowerShell.Commands.WriteErrorException,Test-IsCrescendoCommand"
+        }
+
+        It "Will properly identify the target object" {
+            $badfunction.TargetObject | Should -Be $cmdName
+        }
+    }
+}

--- a/Microsoft.PowerShell.Crescendo/test/ExportCrescendoModule.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/ExportCrescendoModule.Tests.ps1
@@ -12,7 +12,6 @@ Describe "The correct files are created when a module is created" {
         It "Should create the module code" {
             "${TESTDRIVE}/${ModuleName}.psm1" | Should -Exist
         }
-
     }
 
     Context "Configuration with fault" {
@@ -28,7 +27,14 @@ Describe "The correct files are created when a module is created" {
         It "Should create the module code" {
             "${TESTDRIVE}/${ModuleName}.psm1" | Should -Exist
         }
+    }
 
+    Context "Supports -WhatIf" {
+        It "Does not create a module file when WhatIf is used" {
+            $ModuleName = "whatifmodule"
+            Export-CrescendoModule -ModuleName "${TESTDRIVE}/${ModuleName}" -ConfigurationFile "${PSScriptRoot}/assets/FullProxy.json" -WhatIf
+            Test-Path "${TESTDRIVE}/${ModuleName}*" | Should -Be $False
+        }
     }
 
 }


### PR DESCRIPTION
The attribute allows for easy determination of what and what is not a Crescendo command.
Also provide `Test-CrescendoCommand` to discover Crescendo commands.
Create formating output for `Test-CrescendoCommand`.
Add tests for `Test-CrescendoCommand`.