### PR TITLE
Enhancements for next preview

### DIFF
--- a/Microsoft.PowerShell.Crescendo/Samples/GetFileList.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/GetFileList.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/GetSudoers.Crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/GetSudoers.Crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/GetTimeServer.Crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/GetTimeServer.Crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/WinElevateWhoami.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/WinElevateWhoami.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/dd.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/dd.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/Samples/dir.proxy.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/dir.proxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema" : "../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema" : "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb" : "Invoke",

--- a/Microsoft.PowerShell.Crescendo/Samples/dockerRmImage.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/dockerRmImage.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Remove",

--- a/Microsoft.PowerShell.Crescendo/Samples/dockergetimage.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/dockergetimage.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/dockergetps.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/dockergetps.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/dockerinspectimage.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/dockerinspectimage.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/id.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/id.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema" : "../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema" : "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb" : "Get",

--- a/Microsoft.PowerShell.Crescendo/Samples/ifconfig.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/ifconfig.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/Samples/ls.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/ls.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema" : "./Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema" : "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb" : "Invoke",

--- a/Microsoft.PowerShell.Crescendo/Samples/tar.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/tar.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/Samples/who.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/Samples/who.crescendo.json
@@ -1,5 +1,5 @@
 {
-   "$schema" : "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema" : "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
     "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/help/en-US/about_Crescendo.md
+++ b/Microsoft.PowerShell.Crescendo/help/en-US/about_Crescendo.md
@@ -63,7 +63,7 @@ A very simple example is as follows to wrap the unix `/bin/ls` command:
 
 ```json
 {
-    "$schema": "../src/Microsoft.PowerShell.Crescendo.Schema.json",
+    "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
     "Verb": "Get",
     "Noun":"FileList",
     "OriginalName": "/bin/ls",

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json
@@ -1,6 +1,7 @@
 {
   "definitions": {
     "parameter": {
+      "definition": "The description of a parameter.",
       "required": ["ParameterType","Name","OriginalName" ],
       "properties": {
         "ParameterType": {
@@ -13,38 +14,38 @@
         },
         "Name": {
           "type": "string",
-          "description":" the name of the parameter that PowerShell will use."
+          "description": "The name of the parameter that PowerShell will use. If NoGap is used, include the separator in the name. 'parameter=' for parameter=value"
         },
         "OriginalName": {
           "type": "string",
-          "description":" the original parameter name used by the negative command."
+          "description": "The original parameter name used by the negative command."
         },
         "OriginalText": {
           "type": "string",
-          "description":" the original helptext for the native command parameter."
+          "description": "The original help text for the native command parameter."
         },
         "Description": {
           "type": "string",
-          "description":" the description of the parameter, this will be used by help."
+          "description": "The description of the parameter, this will be used by help."
         },
         "DefaultValue": {
           "type": "string",
-          "description":" the default value for the parameter."
+          "description": "The default value for the parameter."
         },
         "DefaultMissingValue": {
           "type": "string",
-          "description":"xxx"
+          "description": "The default value provided if the parameter is not used"
         },
         "AdditionalParameterAttributes": {
           "type": "array",
-          "description":" additional parameter attributes used by PowerShell. This will take the form of a standard script parameter.",
+          "description": "Additional parameter attributes used by PowerShell. This will take the form of a standard script parameter attribute.",
           "items": {
             "type": "string"
           }
         },
         "Mandatory": {
           "type": "boolean",
-          "description":" whether this parameter is mandatory."
+          "description": "A boolean indicating whether this parameter is mandatory."
         },
         "ParameterSetName": {
           "type": "array",
@@ -57,37 +58,37 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of aliases for the cmdlet."
         },
         "OriginalPosition": {
           "type": "integer",
-          "description":" the original parameter position for the native executable. This is used to properly order parameters when calling the native command."
+          "description": "The original parameter position for the native executable. This is used to properly order parameters when calling the native command."
         },
         "ValueFromPipeline": {
           "type": "boolean",
-          "description":" the value for this parameter is taken from the pipeline."
+          "description": "The value for this parameter is taken from the pipeline."
         },
         "NoGap": {
           "type": "boolean",
-          "description":" when constructing the native parameter and volume do not separate with a space."
+          "description": "When constructing the native parameter and value do not separate with a space. Used for native parameters that look like parameter=value"
         },
         "ValueFromPipelineByPropertyName": {
           "type": "boolean",
-          "description":" when are assigning a value to the parameter use the same property as the parameter name."
+          "description": "When are assigning a value to the parameter from a piped object, use the same property as the parameter name."
         },
         "ValueFromRemainingArguments": {
           "type": "boolean",
-          "description":" assign the remaining values to the parameter."
+          "description": "Assign the remaining values to the parameter."
         }
       }
     },
     "command": {
+      "description": "A collection of Crescendo configurations",
       "required": [ "Verb", "Noun", "OriginalName" ],
       "properties": {
         "Verb": {
-          "type": [
-            "string"
-          ],
+          "type": "string",
           "enum": [
             "Add","Approve","Assert",
             "Backup","Block","Build",
@@ -110,7 +111,7 @@
             "Unblock","Undo","Uninstall","Unlock","Unprotect","Unpublish","Unregister","Update","Use",
             "Wait","Watch","Write"
           ],
-          "description" : "The verb of the cmdlet"
+          "description" : "The verb of the cmdlet."
         },
         "Elevation": {
           "type": "object",
@@ -127,12 +128,9 @@
               "description": "Additional arguments required by the elevation command."
             }
           }
-
         },
         "Noun": {
-          "type": [
-            "string"
-          ],
+          "type": "string",
           "description" : "The noun of the cmdlet"
         },
         "Platform": {
@@ -147,9 +145,7 @@
           "description" : "The platform where the function will run, this may be 'Windows','Linux', or 'MacOS' in any combination. The default is all three values."
         },
         "OriginalName": {
-          "type": [
-            "string"
-          ],
+          "type": "string",
           "description" : "The native command to be called by the function."
         },
 
@@ -183,95 +179,76 @@
         },
 
         "OriginalCommandElements": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "description": "Additional elements to be added to the invocation. This is for arguments provided to a Native application which are not part of the parameters."
         },
         "Aliases": {
-          "type": [
-            "array"
-          ],
+          "type": "array",
           "description" : "Aliases to the function that will be created",
           "items": {
-            "type": [
-              "string"
-            ]
+            "type": "string"
           }
         },
         "DefaultParameterSetName": {
-          "type": [
-            "string"
-          ],
+          "type": "string",
           "description": "The default parameter set name for the function"
 
         },
+        "ConfirmImpact": {
+          "type": "string",
+          "enum": ["None", "Low","Medium","High"],
+          "description": "A string indicating the value of Confirm Impact. If not present, this attribute will not be added to the cmdlet declaration."
+        },
         "SupportsShouldProcess": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "A boolean indicating whether this command supports ShouldProcess."
         },
         "SupportsTransactions": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "A boolean indicating whether this command supports transactions."
         },
         "Description": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "The description of the cmdlet.",
+          "type": "string"
         },
         "Usage": {
-          "type": [
-            "object"
-          ],
+          "description": "Information which explains how to use this command.",
+          "type": "object",
           "required": [ "Synopsis" ],
           "properties": {
             "Synopsis": {
-              "type": [
-                "string"
-              ]
+              "description": "The synopsis on how to use this command.",
+              "type": "string"
             },
             "SupportsFlags": {
+              "description": "Unused",
               "type": "boolean"
             },
             "HasOptions": {
+              "description": "Unused",
               "type": "boolean"
             },
             "OriginalText": {
-              "type": [
-                "array",
-                "null"
-              ],
+              "type": "array",
               "items": {
-                "type": [
-                  "string"
-                ]
+                "type": "string"
               },
               "description": "The original text for the command help. Usually generated by command -?"
             }
           }
         },
         "Parameters": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "The parameters for the function.",
           "items": {
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": "object",
             "required": ["ParameterType", "Name", "OriginalName" ],
             "properties": {
               "ParameterType": {
-                "type": [
-                  "string"
-                ],
+                "type": "string",
                 "description": "This the type of the parameter. It should represent an actual type."
               },
               "Position": {
@@ -279,27 +256,20 @@
                 "description": "The position of the parameter."
               },
               "Name": {
-                "type": [
-                  "string"
-                ]
+                "description": "The name of the parameter.",
+                "type": "string"
               },
               "OriginalName": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "description": "The name of the parameter used by the native executable. This can be null.",
+                "type": "string"
               },
               "OriginalText": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "description": "The original text for the native parameter",
+                "type": "string"
               },
               "Description": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "description": "The description of the parameter to be used in help.",
+                "type": "string"
               },
               "DefaultValue": {
                 "type": "string",
@@ -310,111 +280,84 @@
                 "description": "The default value for this parameter if the parameter is not present (or is a switch parameter)."
               },
               "AdditionalParameterAttributes": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "description": "Additional parameter attributes. These should take the form of [ValidateNotNullOrEmpty()], etc.",
+                "type": "array",
                 "items": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 }
               },
               "Mandatory": {
+                "description": "A boolean indicating whether this parameter is mandatory.",
                 "type": "boolean"
               },
               "ParameterSetName": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "description": "The parameter set name for this parameter.",
+                "type": "array",
                 "items": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 }
               },
               "Aliases": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "description": "The parameter alias.",
+                "type": "array",
                 "items": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
+                  "type": "string"
                 }
               },
               "OriginalPosition": {
+                "description": "The position of the parameter for the native executable.",
                 "type": "integer"
               },
               "ValueFromPipeline": {
+                "description": "A boolean indicating whether this parameter accepts piped input.",
                 "type": "boolean"
               },
               "NoGap": {
+                "description": "A boolean indicating whether the constructed parameter should have a gap. This is for parameters which have the shape of parameter=value",
                 "type": "boolean"
               },
               "ValueFromPipelineByPropertyName": {
+                "description": "A boolean indicating whether this parameter accepts piped input which binds to a property name.",
                 "type": "boolean"
               },
               "ValueFromRemainingArguments": {
+                "description": "A boolean indicating whether this parameter gets its value from the remaining arguments.",
                 "type": "boolean"
               }
             }
           }
         },
         "Examples": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "description": "Examples for the command.",
+          "type": "array",
           "items": {
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": "object",
             "required": [ "Command", "Description" ],
             "properties": {
               "Command": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "description": "The command for the example.",
+                "type": "string"
               },
               "OriginalCommand": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "description": "The original command for the example.",
+                "type": "string"
               },
               "Description": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "description": "The description of the example.",
+                "type": "string"
               }
             }
           }
         },
         "OriginalText": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "The original help text of the native command",
+          "type": "string"
         },
         "HelpLinks": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "description": "Help links for the command",
+          "type": "array",
           "items": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": "string"
           }
         },
         "NoInvocation": {
@@ -427,7 +370,7 @@
   },
   "type": "object",
   "$id": "https://microsoft.com/powershell/crescendo",
-  "title": "JSON schema for Powershell Crescendo files",
+  "title": "JSON schema for PowerShell Crescendo files",
   "properties": {
     "$schema": {
       "type": "string"

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
@@ -36,6 +36,7 @@ FunctionsToExport = @(
     'New-CrescendoCommand',
     'New-ParameterInfo',
     'New-UsageInfo',
+    'New-OutputHandler',
     'Import-CommandConfiguration',
     'Export-Schema',
     'Export-CrescendoModule',

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
@@ -8,7 +8,7 @@
 RootModule = 'Microsoft.PowerShell.Crescendo.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.6.1'
+ModuleVersion = '0.7.0'
 
 # ID used to uniquely identify this module
 GUID = '2dd09744-1ced-4636-a8ce-09a0bf0e566a'

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psd1
@@ -39,6 +39,7 @@ FunctionsToExport = @(
     'Import-CommandConfiguration',
     'Export-Schema',
     'Export-CrescendoModule',
+    'Export-CrescendoCommand',
     'Test-IsCrescendoCommand'
     )
 }

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -572,7 +572,7 @@ function Export-CrescendoCommand {
     param (
         [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)]
         [Command[]]$command,
-        [Parameter()][string]$targetDirectory
+        [Parameter()][string]$targetDirectory = "."
     )
 
     PROCESS

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -195,6 +195,7 @@ class Command {
     [string[]] $Aliases
     [string] $DefaultParameterSetName
     [bool] $SupportsShouldProcess
+    [string] $ConfirmImpact
     [bool] $SupportsTransactions
     [bool] $NoInvocation # certain scenarios want to use the generated code as a front end. When true, the generated code will return the arguments only.
 
@@ -477,6 +478,12 @@ class Command {
         if ( $this.SupportsShouldProcess ) {
             $addlAttributes += 'SupportsShouldProcess=$true'
         }
+        if ( $this.ConfirmImpact ) {
+            if ( @("high","medium","low","none") -notcontains $this.ConfirmImpact) {
+                throw ("Confirm Impact '{0}' is invalid. It must be High, Medium, Low, or None." -f $this.ConfirmImpact)
+            }
+            $addlAttributes += 'ConfirmImpact=''{0}''' -f $this.ConfirmImpact
+        }
         if ( $this.DefaultParameterSetName ) {
             $addlAttributes += 'DefaultParameterSetName=''{0}''' -f $this.DefaultParameterSetName
         }
@@ -553,6 +560,13 @@ function New-ExampleInfo {
         [Parameter(Position=2,Mandatory=$true)][string]$description
         )
     [ExampleInfo]::new($command, $originalCommand, $description)
+}
+
+function New-OutputHandler {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions","")]
+    param ( )
+    [OutputHandler]::new()
+
 }
 
 function New-CrescendoCommand {

--- a/Microsoft.PowerShell.Crescendo/test/CmdletAttribute.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/CmdletAttribute.Tests.ps1
@@ -1,0 +1,53 @@
+Describe "Ensure that the cmdlet attribute is created correctly" {
+	BeforeAll {
+		function Get-ConfirmImpactSetting {
+			param ( $name )
+			$function = Get-Item "function:${name}"
+			$function.ScriptBlock.Attributes.ConfirmImpact
+		}
+	}
+	Context "Object model tests for ConfirmImpact" {
+		BeforeAll {
+			$testcases = @{ Level = "High"; Verb = "get"; Noun = "thing1" },
+				@{ Level = "Medium"; Verb = "get"; Noun = "thing2" },
+				@{ Level = "Low"; Verb = "get"; Noun = "thing3" },
+				@{ Level = "None"; Verb = "get"; Noun = "thing4" }
+		}
+
+		It "Can set the ConfirmImpact level to '<Level>'" -TestCases $testcases {
+			param ($Level, $Verb, $Noun)
+			$c = New-CrescendoCommand -Verb $verb -Noun $Noun -OriginalName "nofile"
+			$c.SupportsShouldProcess = $true
+			$c.ConfirmImpact = $Level
+			Invoke-Expression ($c.ToString())
+			$confirmImpactSetting = Get-ConfirmImpactSetting ("${Verb}-${Noun}")
+			$confirmImpactSetting | Should -Be $Level
+			Remove-Item "function:${Verb}-${Noun}"
+		}
+
+		It "Setting ConfirmImpact to an invalid value will result in an error" {
+			$c = New-CrescendoCommand -Verb Get -Noun Thing5 -OriginalName "nofile"
+			$c.SupportsShouldProcess = $true
+			$c.ConfirmImpact = "Zipper"
+			{ $c.ToString() } | Should -Throw
+		}
+
+	}
+	Context "Object model tests for ConfirmImpact" {
+		BeforeAll {
+			$testcases = @{ Setting = "High"; Expected = "High"; Command = "get-thing1" },
+				@{ Setting = "Medium"; Expected = "Medium"; Command = "get-thing2" },
+				@{ Setting = "Low"; Expected = "Low"; Command = "get-thing3" },
+				@{ Setting = "None"; Expected = "None"; Command = "get-thing4" },
+				@{ Setting = ""; Expected = "Medium"; Command = "get-thing5" } # not explicitely set
+			$cmds = Import-CommandConfiguration $PSScriptRoot/assets/SetConfirmImpact.json
+			$cmds.Foreach({Invoke-Expression ($_.ToString())})
+		}
+
+		It "Setting ConfirmImpact to '<Setting>' in configuration is correct" -TestCases $testcases {
+			param ( $Setting, $Expected, $command )
+			$observed = Get-ConfirmImpactSetting $command
+			$observed | Should -Be $Expected
+		}
+	}
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/Alias.Proxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/Alias.Proxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/ArgProxy.noParam1.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ArgProxy.noParam1.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/ArgProxy.noParam2.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ArgProxy.noParam2.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/ArgProxy.withParam.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ArgProxy.withParam.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/BulkProxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/BulkProxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/FullProxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/FullProxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault1.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault1.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Test",

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault2.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault2.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Test",

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault3.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault3.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Test",

--- a/Microsoft.PowerShell.Crescendo/test/assets/MultiConfig.crescendo.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/MultiConfig.crescendo.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+	"$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
 	"Commands": [
 		{
 			"Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/test/assets/MultiHandler.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/MultiHandler.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+	"$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
 	"Commands": [
 		{
 			"Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/SetConfirmImpact.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/SetConfirmImpact.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+	"Commands": [
+		{
+			"Verb": "Get",
+			"Noun": "Thing1",
+			"OriginalName": "/bin/ls",
+			"SupportsShouldProcess": true,
+			"ConfirmImpact": "High"
+		},
+		{
+			"Verb": "Get",
+			"Noun": "Thing2",
+			"OriginalName": "/bin/ls",
+			"SupportsShouldProcess": true,
+			"ConfirmImpact": "Medium"
+		},
+		{
+			"Verb": "Get",
+			"Noun": "Thing3",
+			"OriginalName": "/bin/ls",
+			"SupportsShouldProcess": true,
+			"ConfirmImpact": "Low"
+		},
+		{
+			"Verb": "Get",
+			"Noun": "Thing4",
+			"OriginalName": "/bin/ls",
+			"SupportsShouldProcess": true,
+			"ConfirmImpact": "None"
+		},
+		{
+			"Verb": "Get",
+			"Noun": "Thing5",
+			"SupportsShouldProcess": true,
+			"OriginalName": "/bin/ls"
+		}
+	]
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/SimpleProxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/SimpleProxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/StreamProxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/StreamProxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/dir.proxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/dir.proxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema" : "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema" : "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb" : "Invoke",

--- a/Microsoft.PowerShell.Crescendo/test/assets/functionHandler.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/functionHandler.json
@@ -1,5 +1,5 @@
 {
-   "$schema": "../../src/Microsoft.Powershell.Crescendo.Schema.json",
+   "$schema": "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb": "Get",

--- a/Microsoft.PowerShell.Crescendo/test/assets/ls.proxy.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ls.proxy.json
@@ -1,5 +1,5 @@
 {
-   "$schema" : "../../src/Microsoft.PowerShell.Crescendo.Schema.json",
+   "$schema" : "https://raw.githubusercontent.com/PowerShell/Crescendo/master/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.Schema.json",
    "Commands": [
         {
             "Verb" : "Invoke",


### PR DESCRIPTION
Update schema with more descriptions.
Add support for ConfirmImpact in generator.
Add test for ConfirmImpact
Examples and tests now point to web version of schema rather than the one on disk.
This means that the schema is not needed on disk to develop and you don't need to track relative path to schema.
Add New-OutputHandler function to enable adding output handlers programmatically
Add Export-CrescendoCommand to create configuration from object model
add support for `OriginalName` in `New-CrescendoCommand`
 