### PR TITLE
Add support for parameter which apply to the executable.

### DIFF
--- a/Microsoft.PowerShell.Crescendo/test/MulitStageParameter.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/MulitStageParameter.Tests.ps1
@@ -1,0 +1,12 @@
+#
+Describe "Multistage parameters behave properly" {
+	It "creates parameters for both the executable and the command" {
+		$config = Import-CommandConfiguration ${PSScriptRoot}/assets/MultiStageParameters.json
+		Invoke-Expression ($config.ToString())
+		$result = Invoke-Echo -exeParm1 ep1 -exeParm2 ep2 -cmdParm1 cmd1 -cmdParm2 cmd2  
+		$expectedResult = '-exeParm1=ep1', '-exeParm2', 'ep2', # these are applied to the executable
+				'element1', 'element2', # these are the original command elements
+				'-cmdParm1="cmd1"', '-cmdParm2', 'cmd2' # these are applied after the original command elements
+		$result | Should -Be $expectedResult
+	}
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/MultiStageParameters.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/MultiStageParameters.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://aka.ms/Crescendo/Schema.json",
+	"Commands": [
+		{
+			"Verb": "Invoke",
+			"Noun": "Echo",
+			"OriginalName": "echo",
+			"OriginalCommandElements": [
+				"element1",
+				"element2"
+			],
+			"Parameters": [
+				{
+					"Name": "exeParm1",
+					"OriginalName": "-exeParm1=",
+					"ApplyToExecutable": true,
+					"ParameterType": "string",
+					"NoGap": true
+				},
+				{
+					"Name": "exeParm2",
+					"OriginalName": "-exeParm2",
+					"ApplyToExecutable": true,
+					"ParameterType": "string",
+					"NoGap": false
+				},
+				{
+					"Name": "cmdParm1",
+					"OriginalName": "-cmdParm1=",
+					"ParameterType": "string",
+					"ApplyToExecutable": false,
+					"NoGap": true
+				},
+				{
+					"Name": "cmdParm2",
+					"OriginalName": "-cmdParm2",
+					"ParameterType": "string",
+					"NoGap": false
+				}
+			]
+		}
+	]
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
@@ -12,11 +12,13 @@ BEGIN {
 }
 
 PROCESS {
+    $__boundparms = $PSBoundParameters # debugging assistance
     $__commandArgs = @()
-    $__boundparms = $PSBoundParameters
     $MyInvocation.MyCommand.Parameters.Values.Where({$_.SwitchParameter -and $_.Name -notmatch "Debug|Whatif|Confirm|Verbose" -and ! $PSBoundParameters[$_.Name]}).ForEach({$PSBoundParameters[$_.Name] = [switch]::new($false)})
     if ($PSBoundParameters["Debug"]){wait-debugger}
-    foreach ($paramName in $PSBoundParameters.Keys|Sort-Object {$__PARAMETERMAP[$_].OriginalPosition}) {
+    foreach ($paramName in $PSBoundParameters.Keys|
+        Where-Object {!$__PARAMETERMAP[$_].ApplyToExecutable}|
+        Sort-Object {$__PARAMETERMAP[$_].OriginalPosition}) {
         $value = $PSBoundParameters[$paramName]
         $param = $__PARAMETERMAP[$paramName]
         if ($param) {

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
@@ -16,6 +16,7 @@ BEGIN {
                OriginalPosition = '0'
                Position = '2147483647'
                ParameterType = 'object'
+               ApplyToExecutable = $False
                NoGap = $False
                }
     }
@@ -24,11 +25,13 @@ BEGIN {
 }
 
 PROCESS {
+    $__boundparms = $PSBoundParameters # debugging assistance
     $__commandArgs = @()
-    $__boundparms = $PSBoundParameters
     $MyInvocation.MyCommand.Parameters.Values.Where({$_.SwitchParameter -and $_.Name -notmatch "Debug|Whatif|Confirm|Verbose" -and ! $PSBoundParameters[$_.Name]}).ForEach({$PSBoundParameters[$_.Name] = [switch]::new($false)})
     if ($PSBoundParameters["Debug"]){wait-debugger}
-    foreach ($paramName in $PSBoundParameters.Keys|Sort-Object {$__PARAMETERMAP[$_].OriginalPosition}) {
+    foreach ($paramName in $PSBoundParameters.Keys|
+        Where-Object {!$__PARAMETERMAP[$_].ApplyToExecutable}|
+        Sort-Object {$__PARAMETERMAP[$_].OriginalPosition}) {
         $value = $PSBoundParameters[$paramName]
         $param = $__PARAMETERMAP[$paramName]
         if ($param) {


### PR DESCRIPTION
This supports the docker scenario which has parameters which apply to docker and parameters which apply to the docker command.
`docker --debug image list --digests`

now  you can specify whether the parameter goes before the OriginalCommandElements collection.