### PR TITLE
Fix for issue 101 - Default values are not provided.

### DIFF
--- a/Microsoft.PowerShell.Crescendo/test/DefaultValues.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/DefaultValues.Tests.ps1
@@ -1,0 +1,78 @@
+Describe "Can handle default values correctly" {
+	BeforeAll {
+		$configuration = Import-CommandConfiguration -file "$PSScriptRoot/assets/DefaultValues.json"
+		Invoke-Expression ($configuration.ToString())
+	}
+
+	It "Default values are present when no parameters are provided" {
+		$result = Invoke-Echo
+		$expectedResults = @(
+			"--par1"
+			"defval1"
+			"--par2"
+			"defval2"
+		)
+		$result.count | Should be $expectedResults.Count
+		$result | Should -Be $expectedResults
+	}
+
+	It "overriding default value for parameter 1 does not override parameter 2" {
+		$result = Invoke-Echo -Parameter1 val1
+		$expectedResults = @(
+			"--par1"
+			"val1"
+			"--par2"
+			"defval2"
+		)
+		$result | Should -Be $expectedResults
+	}
+
+	It "overriding default value for parameter 2 does not override parameter 1" {
+		$result = Invoke-Echo -Parameter2 val2
+		$expectedResults = @(
+			"--par1"
+			"defval1"
+			"--par2"
+			"val2"
+		)
+		$result | Should -Be $expectedResults
+	}
+
+	It "overriding all default values" {
+		$result = Invoke-Echo -Parameter1 val1 -Parameter2 val2
+		$expectedResults = @(
+			"--par1"
+			"val1"
+			"--par2"
+			"val2"
+		)
+		$result | Should -Be $expectedResults
+	}
+
+	It "providing 3rd value does not hinder default values" {
+		$result = Invoke-Echo -Parameter3 val3
+		$expectedResults = @(
+			"--par1"
+			"defval1"
+			"--par2"
+			"defval2"
+			"--par3"
+			"val3"
+		)
+		$result | Should -Be $expectedResults
+	}
+
+	It "overriding a value and providing 3rd value does not hinder default value" {
+		$result = Invoke-Echo -Parameter1 val1 -Parameter3 val3
+		$expectedResults = @(
+			"--par1"
+			"val1"
+			"--par2"
+			"defval2"
+			"--par3"
+			"val3"
+		)
+		$result | Should -Be $expectedResults
+	}
+
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/DefaultValues.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/DefaultValues.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://aka.ms/Crescendo/Schema.json",
+	"Commands": [
+		{
+			"Verb": "Invoke",
+			"Noun": "Echo",
+			"OriginalName": "Echo",
+			"Parameters": [
+				{
+					"Name": "Parameter1",
+					"OriginalName": "--par1",
+					"DefaultValue": "defval1",
+					"ParameterType": "string",
+					"OriginalPosition": 0
+				},
+				{
+					"Name": "Parameter2",
+					"OriginalName": "--par2",
+					"DefaultValue": "defval2",
+					"ParameterType": "string",
+					"OriginalPosition": 1
+				},
+				{
+					"Name": "Parameter3",
+					"OriginalName": "--par3",
+					"ParameterType": "string",
+					"OriginalPosition": 2
+				}
+			]
+		}
+	]
+
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
@@ -12,14 +12,16 @@ BEGIN {
 }
 
 PROCESS {
-    $__boundparms = $PSBoundParameters # debugging assistance
+    $__boundParameters = $PSBoundParameters
+    $__defaultValueParameters = $PSCmdlet.MyInvocation.MyCommand.Parameters.Values.Where({$_.Attributes.Where({$_.TypeId.Name -eq "PSDefaultValueAttribute"})}).Name
+    $__defaultValueParameters.Where({ !$__boundParameters["$_"] }).ForEach({$__boundParameters["$_"] = get-variable -value $_})
     $__commandArgs = @()
-    $MyInvocation.MyCommand.Parameters.Values.Where({$_.SwitchParameter -and $_.Name -notmatch "Debug|Whatif|Confirm|Verbose" -and ! $PSBoundParameters[$_.Name]}).ForEach({$PSBoundParameters[$_.Name] = [switch]::new($false)})
-    if ($PSBoundParameters["Debug"]){wait-debugger}
-    foreach ($paramName in $PSBoundParameters.Keys|
+    $MyInvocation.MyCommand.Parameters.Values.Where({$_.SwitchParameter -and $_.Name -notmatch "Debug|Whatif|Confirm|Verbose" -and ! $__boundParameters[$_.Name]}).ForEach({$__boundParameters[$_.Name] = [switch]::new($false)})
+    if ($__boundParameters["Debug"]){wait-debugger}
+    foreach ($paramName in $__boundParameters.Keys|
         Where-Object {!$__PARAMETERMAP[$_].ApplyToExecutable}|
         Sort-Object {$__PARAMETERMAP[$_].OriginalPosition}) {
-        $value = $PSBoundParameters[$paramName]
+        $value = $__boundParameters[$paramName]
         $param = $__PARAMETERMAP[$paramName]
         if ($param) {
             if ( $value -is [switch] ) { $__commandArgs += if ( $value.IsPresent ) { $param.OriginalName } else { $param.DefaultMissingValue } }
@@ -28,8 +30,8 @@ PROCESS {
         }
     }
     $__commandArgs = $__commandArgs|Where-Object {$_}
-    if ($PSBoundParameters["Debug"]){wait-debugger}
-    if ( $PSBoundParameters["Verbose"]) {
+    if ($__boundParameters["Debug"]){wait-debugger}
+    if ( $__boundParameters["Verbose"]) {
          Write-Verbose -Verbose -Message /bin/ls
          $__commandArgs | Write-Verbose -Verbose
     }

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
@@ -25,14 +25,16 @@ BEGIN {
 }
 
 PROCESS {
-    $__boundparms = $PSBoundParameters # debugging assistance
+    $__boundParameters = $PSBoundParameters
+    $__defaultValueParameters = $PSCmdlet.MyInvocation.MyCommand.Parameters.Values.Where({$_.Attributes.Where({$_.TypeId.Name -eq "PSDefaultValueAttribute"})}).Name
+    $__defaultValueParameters.Where({ !$__boundParameters["$_"] }).ForEach({$__boundParameters["$_"] = get-variable -value $_})
     $__commandArgs = @()
-    $MyInvocation.MyCommand.Parameters.Values.Where({$_.SwitchParameter -and $_.Name -notmatch "Debug|Whatif|Confirm|Verbose" -and ! $PSBoundParameters[$_.Name]}).ForEach({$PSBoundParameters[$_.Name] = [switch]::new($false)})
-    if ($PSBoundParameters["Debug"]){wait-debugger}
-    foreach ($paramName in $PSBoundParameters.Keys|
+    $MyInvocation.MyCommand.Parameters.Values.Where({$_.SwitchParameter -and $_.Name -notmatch "Debug|Whatif|Confirm|Verbose" -and ! $__boundParameters[$_.Name]}).ForEach({$__boundParameters[$_.Name] = [switch]::new($false)})
+    if ($__boundParameters["Debug"]){wait-debugger}
+    foreach ($paramName in $__boundParameters.Keys|
         Where-Object {!$__PARAMETERMAP[$_].ApplyToExecutable}|
         Sort-Object {$__PARAMETERMAP[$_].OriginalPosition}) {
-        $value = $PSBoundParameters[$paramName]
+        $value = $__boundParameters[$paramName]
         $param = $__PARAMETERMAP[$paramName]
         if ($param) {
             if ( $value -is [switch] ) { $__commandArgs += if ( $value.IsPresent ) { $param.OriginalName } else { $param.DefaultMissingValue } }
@@ -41,8 +43,8 @@ PROCESS {
         }
     }
     $__commandArgs = $__commandArgs|Where-Object {$_}
-    if ($PSBoundParameters["Debug"]){wait-debugger}
-    if ( $PSBoundParameters["Verbose"]) {
+    if ($__boundParameters["Debug"]){wait-debugger}
+    if ( $__boundParameters["Verbose"]) {
          Write-Verbose -Verbose -Message /bin/ls
          $__commandArgs | Write-Verbose -Verbose
     }


### PR DESCRIPTION
Needed to find a way to find the parameters which had a default value.
Using the `PSDefaultValue` attribute to annotate when a default value was provided.
This is then searched for an added to the bound parameters collection if it wasn't already present.