### PR TITLE
fix space in OriginalName issue

### DIFF
--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -464,7 +464,7 @@ class Command {
         else {
         $sb.AppendLine('    if ($__boundParameters["Debug"]){wait-debugger}')
         $sb.AppendLine('    if ( $__boundParameters["Verbose"]) {')
-        $sb.AppendLine('         Write-Verbose -Verbose -Message ' + $this.OriginalName)
+        $sb.AppendLine('         Write-Verbose -Verbose -Message "' + $this.OriginalName + '"')
         $sb.AppendLine('         $__commandArgs | Write-Verbose -Verbose')
         $sb.AppendLine('    }')
         $sb.AppendLine('    $__handlerInfo = $__outputHandlers[$PSCmdlet.ParameterSetName]')

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
@@ -44,7 +44,7 @@ PROCESS {
     $__commandArgs = $__commandArgs | Where-Object {$_ -ne $null}
     if ($__boundParameters["Debug"]){wait-debugger}
     if ( $__boundParameters["Verbose"]) {
-         Write-Verbose -Verbose -Message /bin/ls
+         Write-Verbose -Verbose -Message "/bin/ls"
          $__commandArgs | Write-Verbose -Verbose
     }
     $__handlerInfo = $__outputHandlers[$PSCmdlet.ParameterSetName]

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
@@ -57,7 +57,7 @@ PROCESS {
     $__commandArgs = $__commandArgs | Where-Object {$_ -ne $null}
     if ($__boundParameters["Debug"]){wait-debugger}
     if ( $__boundParameters["Verbose"]) {
-         Write-Verbose -Verbose -Message /bin/ls
+         Write-Verbose -Verbose -Message "/bin/ls"
          $__commandArgs | Write-Verbose -Verbose
     }
     $__handlerInfo = $__outputHandlers[$PSCmdlet.ParameterSetName]


### PR DESCRIPTION
If OriginalName contains spaces, it needs to be wrapped in double quotes to be interpreted as one string.