### PR TITLE
Don't hardcode the module version when collecting code coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ binskim.log
 binskim-results.xml
 *.pester.xml
 *.swp
+CoverageOutput.xml

--- a/build.ps1
+++ b/build.ps1
@@ -142,7 +142,7 @@ if ($test) {
         `$pesterArgs = @{ PassThru = `$true }
         if ( `$$coverage ) {
             `$pesterArgs['CodeCoverageOutputFile'] = "${PSScriptRoot}/CoverageOutput.xml"
-            `$pesterArgs['CodeCoverage'] = "${PSScriptRoot}/out/Microsoft.PowerShell.Crescendo/0.7.0/Microsoft.PowerShell.Crescendo.psm1"
+            `$pesterArgs['CodeCoverage'] = "${PSScriptRoot}/out/Microsoft.PowerShell.Crescendo/${Version}/Microsoft.PowerShell.Crescendo.psm1"
         }
         `$result = Invoke-Pester @pesterArgs
         if (0 -ne `$result.FailedCount) {


### PR DESCRIPTION
Ignore the coverage output file in gitignore.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The module version was not dynamic for running code coverage
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
