### PR TITLE
Allow the module manifest to not be updated

### DIFF
--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -826,7 +826,8 @@ function Export-CrescendoModule
     param (
         [Parameter(Position=1,Mandatory=$true,ValueFromPipelineByPropertyName=$true)][SupportsWildcards()][string[]]$ConfigurationFile,
         [Parameter(Position=0,Mandatory=$true)][string]$ModuleName,
-        [Parameter()][switch]$Force
+        [Parameter()][switch]$Force,
+        [Parameter()][switch]$NoUpdateManifest
         )
     BEGIN {
         [array]$crescendoCollection = @()
@@ -913,7 +914,10 @@ function Export-CrescendoModule
             $ModuleManifestArguments['AliasesToExport'] = $aliases
         }
 
-        New-ModuleManifest @ModuleManifestArguments
+        # only create the manifest if we are not in no-update-manifest mode
+        if (! $NoUpdateManifest) {
+            New-ModuleManifest @ModuleManifestArguments
+        }
 
         # copy the script output handlers into place
         foreach($config in $crescendoCollection) {

--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -826,8 +826,8 @@ function Export-CrescendoModule
     param (
         [Parameter(Position=1,Mandatory=$true,ValueFromPipelineByPropertyName=$true)][SupportsWildcards()][string[]]$ConfigurationFile,
         [Parameter(Position=0,Mandatory=$true)][string]$ModuleName,
-        [Parameter()][switch]$Force,
-        [Parameter()][switch]$NoUpdateManifest
+        [Parameter(HelpMessage="Overwrite the psm1 and psd1 files.")][switch]$Force,
+        [Parameter(HelpMessage="Do not overwrite the module manifest.")][switch]$NoClobberManifest
         )
     BEGIN {
         [array]$crescendoCollection = @()
@@ -915,7 +915,7 @@ function Export-CrescendoModule
         }
 
         # only create the manifest if we are not in no-update-manifest mode
-        if (! $NoUpdateManifest) {
+        if (! $NoClobberManifest) {
             New-ModuleManifest @ModuleManifestArguments
         }
 

--- a/Microsoft.PowerShell.Crescendo/test/ExportCrescendoModule.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/ExportCrescendoModule.Tests.ps1
@@ -29,6 +29,27 @@ Describe "The correct files are created when a module is created" {
         }
     }
 
+    Context 'Supports NoUpdateManifest' {
+        BeforeAll {
+            $ModuleName = [guid]::NewGuid().ToString("n")
+            $manifestPath = "${TESTDRIVE}/${ModuleName}.psd1"
+            # create an empty manifest
+            $null = New-Item -ItemType File -Path "${TESTDRIVE}/${ModuleName}.psd1"
+        }
+
+        It "A zero length manifest should be present when NoUpdateManifest is set" {
+            $manifestPath | Should -Exist
+            Export-CrescendoModule -ModuleName "${TESTDRIVE}/${ModuleName}" -ConfigurationFile "${PSScriptRoot}/assets/SimpleProxy.json" -Force -NoUpdateManifest
+            (Get-Item $manifestPath).Length | Should -Be 0
+        }
+
+        It "A nonzero length manifest should be present when NoUpdateManifest is not set" {
+            $manifestPath | Should -Exist
+            Export-CrescendoModule -ModuleName "${TESTDRIVE}/${ModuleName}" -ConfigurationFile "${PSScriptRoot}/assets/SimpleProxy.json" -Force
+            (Get-Item $manifestPath).Length | Should -BeGreaterThan 0
+        }
+    }
+
     Context "Supports -WhatIf" {
         It "Does not create a module file when WhatIf is used" {
             $ModuleName = "whatifmodule"

--- a/Microsoft.PowerShell.Crescendo/test/ExportCrescendoModule.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/ExportCrescendoModule.Tests.ps1
@@ -29,7 +29,7 @@ Describe "The correct files are created when a module is created" {
         }
     }
 
-    Context 'Supports NoUpdateManifest' {
+    Context 'Supports NoClobberManifest' {
         BeforeAll {
             $ModuleName = [guid]::NewGuid().ToString("n")
             $manifestPath = "${TESTDRIVE}/${ModuleName}.psd1"
@@ -37,13 +37,13 @@ Describe "The correct files are created when a module is created" {
             $null = New-Item -ItemType File -Path "${TESTDRIVE}/${ModuleName}.psd1"
         }
 
-        It "A zero length manifest should be present when NoUpdateManifest is set" {
+        It "A zero length manifest should be present when NoClobberManifest is set" {
             $manifestPath | Should -Exist
-            Export-CrescendoModule -ModuleName "${TESTDRIVE}/${ModuleName}" -ConfigurationFile "${PSScriptRoot}/assets/SimpleProxy.json" -Force -NoUpdateManifest
+            Export-CrescendoModule -ModuleName "${TESTDRIVE}/${ModuleName}" -ConfigurationFile "${PSScriptRoot}/assets/SimpleProxy.json" -Force -NoClobberManifest
             (Get-Item $manifestPath).Length | Should -Be 0
         }
 
-        It "A nonzero length manifest should be present when NoUpdateManifest is not set" {
+        It "A nonzero length manifest should be present when NoClobberManifest is not set" {
             $manifestPath | Should -Exist
             Export-CrescendoModule -ModuleName "${TESTDRIVE}/${ModuleName}" -ConfigurationFile "${PSScriptRoot}/assets/SimpleProxy.json" -Force
             (Get-Item $manifestPath).Length | Should -BeGreaterThan 0


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a `-NoClobberManifest` parameter to `Export-CrescendoModule` to enable updating the `.psm1` file _only_ and not clobbering the module manifest.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

In an environment where customizations have been done to the module manifest _outside_ of crescendo, it's painful to lose those customizations. This PR adds the `-NoClobberManifest` parameter which will _not_ update the manifest when `Export-CrescendoModule` is invoked.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
