### PR TITLE
Change process for using functions in Argument Transform and Output Hander

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /out/
+/.vscode/
 bin/
 obj/
 /signed/

--- a/Microsoft.PowerShell.Crescendo/test/CrescendoClasses.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/CrescendoClasses.Tests.ps1
@@ -223,7 +223,7 @@ Describe "The class tests" {
 			$oh.HandlerType = "Function"
 			$oh.Handler = "doesnotexist"
 			$cc.OutputHandlers += $oh
-			{ $cc.GetFunctionHandlers() } | Should -Throw -ErrorId "Cannot find output handler function 'doesnotexist'."
+			{ $cc.TestFunctionHandlers() } | Should -Throw -ErrorId "Cannot find output handler function 'doesnotexist'."
 		}
 	}
 

--- a/Microsoft.PowerShell.Crescendo/test/assets/ArgumentTransform2.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ArgumentTransform2.json
@@ -1,0 +1,117 @@
+{
+	"$schema": "https://aka.ms/PowerShell/Crescendo/Schemas/2022-06",
+	"Commands": [
+		{
+			"Verb": "Invoke",
+			"Noun": "Echo1",
+			"OriginalName": "EchoTool",
+			"Parameters": [
+				{
+					"Name": "hasht1",
+					"OriginalName": "--p1",
+					"ParameterType": "hashtable",
+					"OriginalPosition": 0,
+                    "ArgumentTransform": "param([hashtable]$v) $v.Keys.ForEach({''{0}={1}'' -f $_,$v[$_]}) -join '',''"
+				},
+				{
+					"Name": "hasht2",
+					"OriginalName": "--p1ordered",
+					"ParameterType": "System.Collections.Specialized.OrderedDictionary",
+					"OriginalPosition": 0,
+                    "ArgumentTransform": "param([System.Collections.Specialized.OrderedDictionary]$v) $v.Keys.ForEach({''{0}={1}'' -f $_,$v[$_]}) -join '',''"
+				},
+				{
+					"Name": "join",
+					"OriginalName": "--p2",
+					"ParameterType": "string[]",
+					"OriginalPosition": 1,
+                    "ArgumentTransform": "param([string[]]$v) $v -join '',''"
+				},
+                {
+					"Name": "mult2",
+					"OriginalName": "--p3",
+					"ParameterType": "int",
+					"OriginalPosition": 2,
+                    "ArgumentTransform": "param([int]$v) $v * 2"
+				},
+                {
+					"Name": "multmult1",
+					"OriginalName": "--p4",
+					"ParameterType": "int[]",
+					"OriginalPosition": 3,
+                    "ArgumentTransform": "double",
+                    "ArgumentTransformType": "function"
+				},
+                {
+					"Name": "multmult2",
+					"OriginalName": "--p5",
+					"ParameterType": "int[]",
+					"OriginalPosition": 3,
+                    "ArgumentTransform": "param([int[]]$v) [string]::Join('','', $v.foreach({$_ * 2}))"
+				},
+                {
+                    "Name" : "foobar1",
+                    "ArgumentTransform": "myfunction",
+                    "ArgumentTransformType" : "function"
+                }
+			]
+		},
+        {
+			"Verb": "Invoke",
+			"Noun": "Echo2",
+			"OriginalName": "EchoTool",
+			"Parameters": [
+				{
+					"Name": "hasht1",
+					"OriginalName": "--p1",
+					"ParameterType": "hashtable",
+					"OriginalPosition": 0,
+                    "ArgumentTransform": "param([hashtable]$v) $v.Keys.ForEach({''{0}={1}'' -f $_,$v[$_]}) -join '',''"
+				},
+				{
+					"Name": "hasht2",
+					"OriginalName": "--p1ordered",
+					"ParameterType": "System.Collections.Specialized.OrderedDictionary",
+					"OriginalPosition": 0,
+                    "ArgumentTransform": "param([System.Collections.Specialized.OrderedDictionary]$v) $v.Keys.ForEach({''{0}={1}'' -f $_,$v[$_]}) -join '',''"
+				},
+				{
+					"Name": "join",
+					"OriginalName": "--p2",
+					"ParameterType": "string[]",
+					"OriginalPosition": 1,
+                    "ArgumentTransform": "param([string[]]$v) $v -join '',''"
+				},
+                {
+					"Name": "mult2",
+					"OriginalName": "--p3",
+					"ParameterType": "int",
+					"OriginalPosition": 2,
+                    "ArgumentTransform": "param([int]$v) $v * 2"
+				},
+                {
+					"Name": "multmult1",
+					"OriginalName": "--p4",
+					"ParameterType": "int[]",
+					"OriginalPosition": 3,
+                    "ArgumentTransform": "double",
+                    "ArgumentTransformType": "function"
+				},
+                {
+					"Name": "multmult2",
+					"OriginalName": "--p5",
+					"ParameterType": "int[]",
+					"OriginalPosition": 3,
+                    "ArgumentTransform": "param([int[]]$v) [string]::Join('','', $v.foreach({$_ * 2}))"
+				},
+                {
+                    "Name" : "foobar1",
+                    "ArgumentTransform": "transformScript.ps1",
+                    "ArgumentTransformType" : "script"
+                }
+			]
+		}
+        
+	]
+
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault4.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/HandlerFault4.json
@@ -1,0 +1,18 @@
+{
+   "$schema": "https://aka.ms/PowerShell/Crescendo/Schemas/2021-11",
+   "Commands": [
+        {
+            "Verb": "Test",
+            "Noun": "HandlerError3",
+            "OriginalName": "doesnotexist",
+            "OutputHandlers": [
+                {
+                    "ParameterSetName": "pset1",
+                    "StreamOutput": true,
+                    "HandlerType": "Function",
+                    "Handler": "ThisFunctionHandlerDoesNotExist"
+                }
+            ]
+        }
+    ]
+}

--- a/Microsoft.PowerShell.Crescendo/test/assets/MultiHandler.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/MultiHandler.json
@@ -35,7 +35,7 @@
 				{
 					"ParameterSetName": "viaFunction",
 					"HandlerType": "Function",
-					"Handler": "Convert-GetDate"
+					"Handler": "Convert-GetDateFunction"
 				},
 				{
 					"ParameterSetName": "viaScript",

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest1.txt
@@ -1,5 +1,3 @@
-
-
 function Get-Crescendo
 {
 [CmdletBinding()]

--- a/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
+++ b/Microsoft.PowerShell.Crescendo/test/assets/ProxyContentTest2.txt
@@ -1,5 +1,3 @@
-
-
 function Get-Crescendo
 {
 [CmdletBinding()]


### PR DESCRIPTION

The same code does both now as part of the packaging into the psm1. Added more tests for argument transform.
Change moment when the psm1 file is created so errors early on will not result in a partial psm1 file being created.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
