### PR TITLE
Modify how bypass output handler is supported.

### DIFF
--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -183,7 +183,7 @@ class OutputHandler {
     [string]ToString() {
         $s = '        '
         if ($this.HandlerType -eq "ByPass") {
-            '{0} = @{{ StreamOutput = $true; Handler = $null }}' -f $this.ParameterSetName
+            $s += '{0} = @{{ StreamOutput = $true; Handler = $null }}' -f $this.ParameterSetName
         }
         elseif ($this.HandlerType -eq "Inline") {
             $s += '{0} = @{{ StreamOutput = ${1}; Handler = {{ {2} }} }}' -f $this.ParameterSetName, $this.StreamOutput, $this.Handler
@@ -792,6 +792,9 @@ function Test-Configuration
 
     # Validate the output handlers in the configuration
     foreach ( $handler in $configuration.OutputHandlers ) {
+        if ( $handler.HandlerType -eq "bypass") {
+            continue
+        }
         $parserErrors = $null
         if ( -not (Test-Handler -Script $handler.Handler -ParserErrors ([ref]$parserErrors))) {
             $configurationOK = $false

--- a/Microsoft.PowerShell.Crescendo/test/OutputHandler.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/OutputHandler.Tests.ps1
@@ -58,4 +58,8 @@ PROCESS { "script:" + $date.date.ToString("MM/dd/yyyy") }
             Should -Throw -ErrorId "Cannot find output handler function 'ThisFunctionHandlerDoesNotExist'."
     }
 
+    It "will handle an output handler of type 'Bypass'" {
+        Invoke-GetDate2 | Should -BeOfType [DateTime]
+    }
+
 }

--- a/Microsoft.PowerShell.Crescendo/test/assets/MultiHandler.json
+++ b/Microsoft.PowerShell.Crescendo/test/assets/MultiHandler.json
@@ -43,6 +43,18 @@
 					"Handler": "Convert-GetDate.ps1"
 				}
 			]
-		}
+		},
+		{
+			"Verb": "Invoke",
+			"Noun": "GetDate2",
+			"OriginalName": "Get-Date",
+			"OriginalCommandElements": [ "7/1/2021 12:00:00 AM"],
+            "OutputHandlers": [
+                {
+                    "ParameterSetName": "Default",
+                    "HandlerType": "Bypass"
+                }
+            ]
+        }
 	]
 }


### PR DESCRIPTION
- Fix bug where the handler was not added to the outputhandler collection if the type was 'bypass'.
- Do not bother to check the output hander existence or syntax if it is a bypass type.
- Add test for output type bypass.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

setting the hander type to bypass would omit it from the outputhandler collection, and there's no reason
to check the syntax of a handler which is not going to be used.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
