### PR TITLE
Fix an issue when exporting a configuration.

### DIFF
--- a/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
+++ b/Microsoft.PowerShell.Crescendo/src/Microsoft.PowerShell.Crescendo.psm1
@@ -755,7 +755,7 @@ function Export-CrescendoCommand {
         # now save all the command configurations to a single file.
         $multiConfiguration = [System.Collections.Specialized.OrderedDictionary]::new()
         $multiConfiguration.Add('$schema', 'https://aka.ms/PowerShell/Crescendo/Schemas/2022-06')
-        $multiConfiguration.Add('commands', $commandConfigurations)
+        $multiConfiguration.Add('Commands', $commandConfigurations)
         $sOptions = [System.Text.Json.JsonSerializerOptions]::new()
         $sOptions.WriteIndented = $true
         $sOptions.MaxDepth = 10

--- a/Microsoft.PowerShell.Crescendo/test/ExportCrescendoCommand.Tests.ps1
+++ b/Microsoft.PowerShell.Crescendo/test/ExportCrescendoCommand.Tests.ps1
@@ -35,6 +35,13 @@ Describe "Export-CrescendoCommand tests" {
             $modName = $file -replace ".json", "_module"
             Export-CrescendoModule -ModuleName "${testdrive}/${modName}" -ConfigurationFile $filePath -Force
         }
+
+        # check for proper case of commands element
+        It "The exported file '<file>' should have the proper 'Commands' element" -testcases $testCases {
+            param ($file)
+            $obj = Get-Content (Join-Path $testdrive $file) | ConvertFrom-Json
+            $obj.PSObject.Properties.Where({$_.Name -eq "commands"}).Name | Should -BeExactly "Commands"
+        }
 	}
 
 	Context "SingleFile parameter set" {


### PR DESCRIPTION
Be sure that the 'Commands' element is properly cased.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When using `Export-CrescendoCommand` the "Commands" element would have the wrong case, so authoring
tools (VSCode) wouldn't be able to provide intellisense or tool-tips because it needs to have the proper case
to work correctly.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
